### PR TITLE
Vmware master

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,51 +18,72 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
+
+MKFILE := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
+SRCDIR := $(dir $(abspath $(MKFILE)))
+SRCROOT := $(SRCDIR:%/=%)
+
 default: vmw_conn_oss
 
 all: vmw_conn_oss install
 
-INCLUDES=-I./include/ -I/usr/include
-
 ifndef LIB_NETFILTER_INCLUDE
-LIB_NETFILTER_INCLUDE=-I/usr/src/debug/libnetfilter_conntrack-1.0.6/include/
+LIB_NETFILTER_INCLUDE := -I/usr/src/debug/libnetfilter_conntrack-1.0.6/include
 endif
 
-GLIB_INCLUDES=-I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include/ $(LIB_NETFILTER_INCLUDE) 
-CFLAGS=$(INCLUDES) $(GLIB_INCLUDES) -g
-VMW_OPEN_LIBNETFLT_OBJS=-L/usr/lib64/,/usr/lib/x86_64-linux-gnu/lib, \
-								 -lmnl -lnfnetlink -lpthread\
-								 -lnetfilter_queue -lnetfilter_conntrack -lglib-2.0
+CC := gcc
+
+GLIB_INCLUDES := -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include
+
+INCLUDES := \
+	-I./include/ \
+	-I/usr/include \
+	-I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
+	$(GLIB_INCLUDES) \
+	$(LIB_NETFILTER_INCLUDE)
+
+CFLAGS := -Wall -Wextra -Werror -Wno-unused-parameter -g $(INCLUDES)
+
+LDFLAGS := \
+	-L/usr/lib64/ \
+	-L/usr/lib/x86_64-linux-gnu/lib \
+	-lpthread \
+	-lglib-2.0 \
+	-lmnl \
+	-lnfnetlink \
+	-lnetfilter_queue \
+	-lnetfilter_conntrack
+
+VMW_OPEN_SOURCE_BIN := $(SRCROOT)/vmw_conn_notify
+
+VMW_INSTALL_CONFDIR := /etc/vmw_conn_notify
+VMW_INSTALL_INITDIR := /etc/init.d
 
 ###############################
 # vmw_conn_notify open source
 ###############################
-NET_OPEN_SOURCE =\
-		   ./vmw_conn_main.c \
-		   ./vmw_conn_netfilter.c
+VMW_OPEN_SOURCE_SRCS := \
+	$(SRCROOT)/vmw_conn_main.c \
+	$(SRCROOT)/vmw_conn_netfilter.c
 
+VMW_OPEN_SOURCE_OBJS := \
+	$(SRCROOT)/vmw_conn_main.o \
+	$(SRCROOT)/vmw_conn_netfilter.o
 
-VMW_OPEN_SOURCE_OBJS=\
-		      ./vmw_conn_main.o \
-		      ./vmw_conn_netfilter.o
+$(VMW_OPEN_SOURCE_OBJS): %.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
 
-vmw_conn_oss:   $(VMW_OPEN_SOURCE_OBJS)
-	$(CC) $(CC_DEBUG_OPTS) $(CC_WARNINGS) $(CC_OPTS) $(INCLUDES) \
-	$(GLIB_INCLUDES) -o \
-	./vmw_conn_notify \
-	$(VMW_OPEN_SOURCE_OBJS) \
-	$(LDFLAGS) \
-	$(VMW_OPEN_LIBNETFLT_OBJS) \
-	$(CC_LIB_PATHS) \
+vmw_conn_oss: $(VMW_OPEN_SOURCE_OBJS)
+	$(CC) -o $(VMW_OPEN_SOURCE_BIN) $(VMW_OPEN_SOURCE_OBJS) $(LDFLAGS)
 
 install:
-	mkdir -p /etc/vmw_conn_notify
-	cp ./vmw_conn_notify.conf /etc/vmw_conn_notify/
-	cp ./vmw_conn_notifyd /etc/init.d/
-	chmod 755 /etc/init.d/vmw_conn_notifyd
-	cp ./vmw_conn_notify /usr/sbin/
+	mkdir -p $(VMW_INSTALL_CONFDIR)
+	cp $(SRCROOT)/vmw_conn_notify.conf $(VMW_INSTALL_CONFDIR)
+	cp $(SRCROOT)/vmw_conn_notifyd $(VMW_INSTALL_INITDIR)
+	chmod 755 $(VMW_INSTALL_INITDIR)/vmw_conn_notifyd
+	cp $(VMW_OPEN_SOURCE_BIN) /usr/sbin/
 	chmod 755 /usr/sbin/vmw_conn_notify
 
 clean:
-	rm *.o
-	rm vmw_conn_notify 
+	rm -f $(VMW_OPEN_SOURCE_OBJS)
+	rm -f $(VMW_OPEN_SOURCE_BIN)

--- a/src/include/vmw_conn.h
+++ b/src/include/vmw_conn.h
@@ -78,8 +78,11 @@
  * interested in. These macros indicate how the bits in the 'protocol'
  * field of vmw_client_info are interpreted.
  */
-#define TCP_SUPPORT 1<<0
-#define UDP_SUPPORT 1<<1
+#define TCP_OUT_PRE_CONN_SUPPORT 1<<0
+#define TCP_IN_PRE_CONN_SUPPORT  1<<1
+#define TCP_EST_CONN_SUPPORT     1<<2
+#define TCP_CLOSE_CONN_SUPPORT   1<<3
+#define UDP_SUPPORT              1<<4
 
 /* Network event Type */
 enum vmw_conn_event_type {

--- a/src/vmw_conn_netfilter.c
+++ b/src/vmw_conn_netfilter.c
@@ -468,7 +468,6 @@ vmw_client_msg_recv(void *arg)
       }
    }
 
-exit:
    return NULL;
 }
 
@@ -478,11 +477,8 @@ vmw_conn_data_send(struct vmw_conn_identity_data *conn_data,
                    uint32_t packet_mark)
 {
    global_packet_info *global_packet = NULL;
-   gpointer key;
-   gpointer value = NULL;
    int i, sd;
    int ret = 0, refcnt = 0;
-   uint32_t mark = 0;
 
    /*
     * The event id of each contrack event is zero. The conntrack event
@@ -889,7 +885,6 @@ vmw_net_queue_callback(struct nfq_q_handle *qh,
    struct vmw_conn_identity_data *conn_data = NULL;
    struct vmw_net_session *sess = (struct vmw_net_session*)arg;
    int ret = -1;
-   int status = 0;
    enum vmw_conn_event_type event_type = 0;
    unsigned char *data = NULL;
    uint32_t event_id;
@@ -905,7 +900,6 @@ vmw_net_queue_callback(struct nfq_q_handle *qh,
            malloc(sizeof(struct vmw_conn_identity_data));
    if (!conn_data) {
       ERROR("Memory allocation failed for msg data");
-      status = ENOMEM;
       ret = -1;
       goto exit;
    }


### PR DESCRIPTION
Refactor Makefile and Fix Broken Build

Problem Description
Refactor Makefile and Fix Broken Build

Fix Description
1. Refactor Makefile and remove undefined variables

2. Fix broken build - Fix definitions of protocol fields
TCP_OUT_PRE_CONN_SUPPORT
TCP_IN_PRE_CONN_SUPPORT
TCP_EST_CONN_SUPPORT
TCP_CLOSE_CONN_SUPPORT
UDP_SUPPORT

3. Remove unused assigned variables.

Testing Details
make succeeds

Impact on existing Inter Process Communication
None
