### PR TITLE
Fix Version Packing

### DIFF
--- a/src/include/vmw_conn.h
+++ b/src/include/vmw_conn.h
@@ -68,7 +68,12 @@
 #define DEBUG(fmt, ...) LOG_MSG(LOG_DEBUG, "DEBUG", fmt, ##__VA_ARGS__)
 #define NOTICE(fmt, ...) LOG_MSG(LOG_NOTICE, "NOTICE", fmt, ##__VA_ARGS__)
 
-#define PROG_NAME "vmw_conn_notfiy"
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 1
+#define VERSION_BUILD 0
+#define VERSION_REVISION 0
+
+#define PROG_NAME "vmw_conn_notify"
 
 /* Maximum number of supported client */
 #define MAX_CLIENTS 2


### PR DESCRIPTION
Problem Description
Fix Version Packing to avoid collisions.

Fix Description
Pack version into 32 bit integer assigning each byte for
major, minor, build and revision.
Earlier scheme was prone to collisions.
(Producing same integer for different versions.)

Testing Details
Make succeeds

Syslog
vmw_conn_notify[31796]: INFO: vmw_pack_version:
    vmw_conn_notify protocol version 1.1.0.0 0x1010000
vmw_conn_notify[31796]: INFO: vmw_handshake_version:
    Adding client to the client connection list socket 7
    version 1010000 protocol 0

Impact on existing Inter Process Communication

This change updates the version to 1.1.0.0
As the newer code is not compatible with 1.0 version,
the minor version is incremented.

For working with the current version, clients need to make change
and interpret version properly.
For example, current version will be encoded as 0x1100 in the protocol.

Issue 5